### PR TITLE
fix: 쿠폰 중복 발행 400 -> 409 수정

### DIFF
--- a/src/main/java/com/nhnacademy/coupon_server/exception/ErrorCode.java
+++ b/src/main/java/com/nhnacademy/coupon_server/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 
     // Coupon
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "CO001", "존재하지 않는 쿠폰입니다."),
-    DUPLICATE_COUPON_ISSUE(HttpStatus.BAD_REQUEST, "CO002", "이미 발급된 쿠폰입니다."),
+    DUPLICATE_COUPON_ISSUE(HttpStatus.CONFLICT, "CO002", "이미 발급된 쿠폰입니다."),
 
     // Member Coupon
     MEMBER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "MC001", "회원 쿠폰을 찾을 수 없습니다.");

--- a/src/test/java/com/nhnacademy/coupon_server/controller/MemberCouponControllerTest.java
+++ b/src/test/java/com/nhnacademy/coupon_server/controller/MemberCouponControllerTest.java
@@ -73,7 +73,7 @@ class MemberCouponControllerTest {
     }
 
     @Test
-    @DisplayName("사용자 쿠폰 발급 실패 - 이미 발급된 쿠폰 (400)") // [수정] 409 -> 400
+    @DisplayName("사용자 쿠폰 발급 실패 - 이미 발급된 쿠폰 (409)")
     void issueCouponFailureDuplicateCoupon() throws Exception {
         Long userId = 1L;
         Long couponId = 100L;
@@ -87,13 +87,13 @@ class MemberCouponControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(print())
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(ErrorCode.DUPLICATE_COUPON_ISSUE.getCode()))
                 .andExpect(jsonPath("$.message").value(ErrorCode.DUPLICATE_COUPON_ISSUE.getMessage()));
     }
 
     @Test
-    @DisplayName("사용자 쿠폰 발급 실패 - 발급 기간 아님/수량 소진 (400)")
+    @DisplayName("사용자 쿠폰 발급 실패 - 발급 기간 아님/수량 소진 (409)")
     void issueCouponFailureBadRequest() throws Exception {
         Long userId = 1L;
         Long couponId = 100L;

--- a/src/test/java/com/nhnacademy/coupon_server/service/MemberCouponServiceTest.java
+++ b/src/test/java/com/nhnacademy/coupon_server/service/MemberCouponServiceTest.java
@@ -370,11 +370,9 @@ public class MemberCouponServiceTest {
     void handleExceptionTest() {
         DuplicateCouponException ex = new DuplicateCouponException();
 
-        // [수정] 변경된 핸들러 메소드 호출 및 반환 타입(ErrorResponse) 확인
         ResponseEntity<ErrorResponse> res = globalExceptionHandler.handleCouponServerException(ex);
 
-        // [수정] ErrorCode에 정의된 Status 확인 (BAD_REQUEST)
-        Assertions.assertEquals(HttpStatus.BAD_REQUEST, res.getStatusCode());
+        Assertions.assertEquals(HttpStatus.CONFLICT, res.getStatusCode());
         Assertions.assertEquals(ErrorCode.DUPLICATE_COUPON_ISSUE.getCode(), res.getBody().getCode());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 쿠폰 중복 발행 시 에러 코드 400에서 409로 변경함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 중복 쿠폰 발급 시 반환되는 HTTP 상태 코드가 400에서 409(Conflict)로 조정되어 클라이언트가 중복 상태를 명확히 구분할 수 있습니다.

* **테스트**
  * 중복 쿠폰 관련 단위/통합 테스트들이 새로운 409 상태 코드 기대값으로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->