### PR TITLE
fix: redis와 DB사이에 불일치로 인한 쿠폰 발행 실패 해결

### DIFF
--- a/src/main/java/com/nhnacademy/coupon_server/service/impl/MemberCouponServiceImpl.java
+++ b/src/main/java/com/nhnacademy/coupon_server/service/impl/MemberCouponServiceImpl.java
@@ -112,7 +112,10 @@ public class MemberCouponServiceImpl implements MemberCouponService {
                 throw new IllegalStateException("쿠폰이 모두 소진되었습니다.");
             }
             if (result == -1) {
-                throw new DuplicateCouponException();
+                if (memberCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+                    throw new DuplicateCouponException();
+                }
+                log.warn("Redis 불일치 감지: Redis 발급 이력 있음 / DB 없음 -> 재저장 시도 (User: {}, Coupon: {})", userId, couponId);
             }
         }
         saveMemberCoupon(userId, coupon);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 spring:
   application:
     name: TEAM5-COUPON-SERVER
+  #  cloud:
+  #    config:
+  #      enabled: false
   config:
-    name: TEAM5-COUPON-SERVER
     import: "optional:configserver:"
 
 # ▼ [필수 추가] 이 부분이 없으면 Docker가 주는 유레카 주소를 못 받습니다!

--- a/src/test/java/com/nhnacademy/coupon_server/service/MemberCouponServiceTest.java
+++ b/src/test/java/com/nhnacademy/coupon_server/service/MemberCouponServiceTest.java
@@ -176,6 +176,9 @@ public class MemberCouponServiceTest {
         when(redisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
                 .thenReturn(-1L);
 
+        when(memberCouponRepository.existsByUserIdAndCouponId(userId, couponId))
+                .thenReturn(true);
+
         Assertions.assertThrows(DuplicateCouponException.class, () ->
                 memberCouponService.issueCouponByUser(userId, couponId)
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> redis와 DB사이에 불일치로 인한 쿠폰 발행 실패 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 쿠폰 발급 시 캐시와 DB 간 불일치 상황을 처리하도록 개선했습니다. 중복 여부를 확인하고 필요한 경우 DB 저장을 재시도해 발급 안정성을 높였습니다.

* **테스트**
  * 중복 상황을 더 정확히 시뮬레이션하는 단위 테스트를 추가/보강해 예외 처리 동작을 검증합니다.

* **잡무**
  * 설정 파일에 주석 형태의 구성 관련 변경을 반영했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->